### PR TITLE
Feat: Add link to navigate to the registration page from login page

### DIFF
--- a/src/components/ButtonTag/ButtonTag.scss
+++ b/src/components/ButtonTag/ButtonTag.scss
@@ -23,7 +23,7 @@
 
 .button__registration,
 .button__login {
-  margin: 20px 0px 0px 0px;
+  margin: 20px 0px 13px 0px;
   padding: 16px 0px;
   font-size: 16px;
   font-weight: 700;

--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -43,6 +43,7 @@ function InputTag({ type, id, onChange }: InputTagProps): JSX.Element {
       className={styleInput}
       placeholder={placeholder}
       onChange={onChange}
+      autoComplete={type === "password" ? "current-password" : "on"}
     />
   );
 }

--- a/src/pages/LoginPage/LoginPage.scss
+++ b/src/pages/LoginPage/LoginPage.scss
@@ -33,5 +33,15 @@
       line-height: 16px;
       text-align: left;
     }
+
+    .login-page__content_sing-up {
+      max-width: 300px;
+      width: 100%;
+      text-align: right;
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 16px;
+      color: rgb(70, 163, 88);
+    }
   }
 }

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,5 +1,6 @@
 import "./LoginPage.scss";
 import React, { useState, ReactElement } from "react";
+import { NavLink } from "react-router-dom";
 
 import FormWrapper from "../../components/FormWrapper/FormWrapper";
 import FormTag from "../../components/Form/FormTag";
@@ -39,6 +40,9 @@ function LoginPage(): ReactElement {
 
         <ButtonTag type="submit" title="Login" />
       </FormTag>
+      <NavLink className="login-page__content_sing-up" to="/registration">
+        Have an account? Sign Up
+      </NavLink>
     </FormWrapper>
   );
 }

--- a/src/pages/RegistrationPage/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage/RegistrationPage.tsx
@@ -54,10 +54,10 @@ function RegistrationPage(): ReactElement {
       email: formData.email,
       password: formData.password,
     };
-    
+
     clientAPI.createCustomer(newUserData);
   };
-  
+
   return (
     <FormWrapper title="Register">
       <FormTag


### PR DESCRIPTION
## Pull Request - Title PR (RSS-ECOMM-2_08: Add a button to navigate to the registration page [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_08.md))

### What type of PR is this?

- [x] 🌟 Feature
- [x] 🛠 Bug Fix
- [ ] ⚙️ Refactor
- [ ] 📖 Documentation

### Description

- **Brief Overview:**
1. Added a link to go from the login page to the registration page, provided that this user is not in the database.
2. Fixed a bug in the console related to auto-completion of a password type input

### Additional Information

- **Screenshots/Links:**
  ![image](https://github.com/Oleg-Melnikow/eCommerce/assets/122875105/03e30f15-adcb-41d2-881f-3cd9c6ae82ce)

### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
