### PR TITLE
Feat: RSS-ECOMM-2_15 billing and shipping addresses during registration

### DIFF
--- a/src/api/API.tsx
+++ b/src/api/API.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance, AxiosResponse } from "axios";
+import axios, { AxiosInstance, AxiosResponse } from "axios";
 import { toast } from "react-toastify";
 import {
   CustomerSignInResult,
@@ -6,8 +6,6 @@ import {
   MyCustomerSignin,
 } from "types/API/Customer";
 import errorHandler from "../helpers/errorHandler";
-
-import toastOptions from "../helpers/toastOptions";
 
 export default class API {
   protected static instance: API | null = null;
@@ -150,34 +148,25 @@ export default class API {
     }
   }
 
-  public async createCustomer(customerData: MyCustomerDraft): Promise<void> {
+  public async createCustomer(
+    customerData: MyCustomerDraft
+  ): Promise<CustomerSignInResult | undefined> {
     const createAPIBinded = this.createAPI.bind(this);
-    if (this.apiInstance)
-      toast.promise(
-        this.apiInstance?.post("/me/signup", customerData),
-        {
-          pending: "Please, wait.",
-          success: {
-            render(props) {
-              const response = props.data as AxiosResponse;
-              if (response.status === 201) {
-                createAPIBinded(customerData);
-                return "Registration was successfull";
-              }
-              throw new Error(
-                "Something went wrong during the registration process. Please, should try again later."
-              );
-            },
-          },
-          error: {
-            render(props) {
-              const error = props.data as AxiosError;
-              return `${errorHandler(props)}`;
-            },
-          },
-        },
-        toastOptions
-      );
+    return this.apiInstance
+      ?.post("/me/signup", customerData)
+      .then((response) => {
+        if (response?.status === 201) {
+          console.log(response.data, "api res");
+          createAPIBinded(customerData);
+          return response?.data as CustomerSignInResult;
+        }
+        throw new Error(
+          "Something went wrong during the registration process. Please, should try again later."
+        );
+      })
+      .catch((error) => {
+        throw new Error(`${errorHandler(error)}`);
+      });
   }
 
   public async signInCustomer(

--- a/src/components/AddressFields/AddressFields.tsx
+++ b/src/components/AddressFields/AddressFields.tsx
@@ -1,0 +1,141 @@
+import { FormControlLabel, Grid, Typography } from "@mui/material";
+import InputTag from "components/InputTag/InputTag";
+import SelectTag from "components/SelectTag/SelectTag";
+import { FormTypeRegister } from "pages/RegistrationPage/RegistrationPage";
+import { ChangeEvent, ReactElement } from "react";
+import { Control, Controller, FieldErrors } from "react-hook-form";
+import Switch from "@mui/material/Switch";
+import Checkbox from "@mui/material/Checkbox";
+
+type PropsType = {
+  typeAddress: "shipping" | "billing";
+  control: Control<FormTypeRegister>;
+  errors: FieldErrors<FormTypeRegister>;
+  isDefault: boolean;
+  isCheckedBilling: boolean;
+  onChangeIsDefault: (event: ChangeEvent<HTMLInputElement>) => void;
+  onCheckedBilling: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function AddressFields({
+  typeAddress,
+  control,
+  errors,
+  isDefault,
+  onChangeIsDefault,
+  isCheckedBilling,
+  onCheckedBilling,
+}: PropsType): ReactElement {
+  const errorsField =
+    typeAddress === "shipping" ? errors.shippingAddress : errors.billingAddress;
+  const nameField =
+    typeAddress === "shipping" ? "shippingAddress" : "billingAddress";
+
+  return (
+    <>
+      <Typography
+        sx={{ mt: 2, alignSelf: "flex-start", textTransform: "capitalize" }}
+        variant="body1"
+      >
+        {typeAddress} Address
+      </Typography>
+      <Grid container xs={12} spacing={1} item>
+        <Grid item md={6} xs={12}>
+          <Controller
+            name={`${nameField}.country`}
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <SelectTag
+                valueTag={value}
+                id={name}
+                onChange={onChange}
+                isError={Boolean(errorsField?.country)}
+                message={errorsField?.country?.message}
+              />
+            )}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <Controller
+            name={`${nameField}.postalCode`}
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <InputTag
+                value={value}
+                type="text"
+                label="Postal Code"
+                name={name}
+                onChange={onChange}
+                isError={Boolean(errorsField?.postalCode)}
+                message={errorsField?.postalCode?.message}
+              />
+            )}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <Controller
+            name={`${nameField}.city`}
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <InputTag
+                value={value}
+                type="text"
+                label="City"
+                name={name}
+                onChange={onChange}
+                isError={Boolean(errorsField?.city)}
+                message={errorsField?.city?.message}
+              />
+            )}
+          />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <Controller
+            name={`${nameField}.street`}
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <InputTag
+                value={value}
+                type="text"
+                label="Street"
+                name={name}
+                onChange={onChange}
+                isError={Boolean(errorsField?.street)}
+                message={errorsField?.country?.message}
+              />
+            )}
+          />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormControlLabel
+            value="end"
+            control={
+              <Switch
+                color="success"
+                checked={isDefault}
+                onChange={onChangeIsDefault}
+              />
+            }
+            label="Set as default address"
+            labelPlacement="end"
+          />
+        </Grid>
+        {typeAddress === "shipping" && (
+          <Grid item xs={12} sm={6}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="CheckboxBilling"
+                  color="success"
+                  checked={isCheckedBilling}
+                  onChange={onCheckedBilling}
+                />
+              }
+              label="Also use as billing address"
+            />
+          </Grid>
+        )}
+      </Grid>
+    </>
+  );
+}

--- a/src/components/AddressFields/AddressFields.tsx
+++ b/src/components/AddressFields/AddressFields.tsx
@@ -1,7 +1,7 @@
 import { FormControlLabel, Grid, Typography } from "@mui/material";
 import InputTag from "components/InputTag/InputTag";
 import SelectTag from "components/SelectTag/SelectTag";
-import { FormTypeRegister } from "pages/RegistrationPage/RegistrationPage";
+import { FormTypeRegister } from "types/RegisterForm";
 import { ChangeEvent, ReactElement } from "react";
 import { Control, Controller, FieldErrors } from "react-hook-form";
 import Switch from "@mui/material/Switch";

--- a/src/components/Form/FormTag.scss
+++ b/src/components/Form/FormTag.scss
@@ -8,3 +8,8 @@
   width: 100%;
   background-color: rgb(255, 255, 255);
 }
+
+.registration-page__form {
+  max-width: 100%;
+  padding: 0 20px;
+}

--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -1,4 +1,9 @@
-import { IconButton, InputAdornment, TextField } from "@mui/material";
+import {
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  TextField,
+} from "@mui/material";
 import { InputTagProps } from "types/InputTagProps";
 import { ReactElement, useState } from "react";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
@@ -56,33 +61,41 @@ function InputTag({
   const date = new Date();
 
   return (
-    <TextField
-      variant="outlined"
-      fullWidth
-      size="small"
-      sx={{ mt: 2 }}
-      label={label}
-      value={value || ""}
-      type={inputType}
-      name={name}
-      id={name}
-      onChange={onChange}
-      InputProps={{
-        inputProps: {
-          max: `2024-05-${date.getDate()}`,
-        },
-        endAdornment: type === "password" && (
-          <PasswordButton
-            showPassword={showPassword}
-            handleClickShowPassword={handleClickShowPassword}
-            handleMouseDownPassword={handleMouseDownPassword}
-          />
-        ),
-      }}
-      FormHelperTextProps={{ sx: { margin: 0 } }}
-      error={isError}
-      helperText={message || ""}
-    />
+    <>
+      {type === "date" && (
+        <InputLabel sx={{ fontSize: 14 }} error={isError}>
+          {label}
+        </InputLabel>
+      )}
+      <TextField
+        variant="outlined"
+        fullWidth
+        size="small"
+        sx={{ mt: type !== "date" ? 2 : 0, bottom: type === "date" ? 4 : 0 }}
+        label={type !== "date" ? label : ""}
+        value={value || ""}
+        type={inputType}
+        name={name}
+        id={name}
+        onChange={onChange}
+        InputProps={{
+          inputProps: {
+            min: "1904-01-01",
+            max: `2024-05-${date.getDate()}`,
+          },
+          endAdornment: type === "password" && (
+            <PasswordButton
+              showPassword={showPassword}
+              handleClickShowPassword={handleClickShowPassword}
+              handleMouseDownPassword={handleMouseDownPassword}
+            />
+          ),
+        }}
+        FormHelperTextProps={{ sx: { margin: 0 } }}
+        error={isError}
+        helperText={message || ""}
+      />
+    </>
   );
 }
 

--- a/src/helpers/validatioinSchemes.ts
+++ b/src/helpers/validatioinSchemes.ts
@@ -20,31 +20,34 @@ const loginSchema = z.object({
     .max(32),
 });
 
-const registrationSchema = z.object({
-  firstName: z
-    .string({ message: "First name is a required field" })
-    .regex(/^[a-zA-Z\s]+$/, "First name only letter")
-    .min(1),
-  lastName: z
-    .string({ message: "Last name is a required field" })
-    .regex(/^[a-zA-Z\s]+$/, "Last name only letter")
-    .min(1),
+const validateAdress = z.object({
+  street: z.string({ message: "Street is a required field" }).min(1),
+  postalCode: z.string({ message: "Postal code is a required field" }).min(1),
+  country: z.string({ message: "Country is a required field" }),
   city: z
     .string({ message: "City is a required field" })
     .regex(/^[a-zA-Z\s]+$/, "City only letter")
     .min(1),
-  street: z.string().min(1),
-  postalCode: z.string().min(1),
-  confirmPassword: z.string({ message: "Passwords do not match" }),
-  country: z.string({ message: "Country is a required field" }),
-  dateOfBirth: z.string({ message: "Date is a required field" }).date(),
 });
 
-const registration = registrationSchema
-  .merge(loginSchema)
-  .refine((values) => values.password === values.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  });
+const validateNames = (name: string): z.ZodString => {
+  return z
+    .string({ message: `${name} name is a required field` })
+    .regex(/^[a-zA-Z\s]+$/, `${name} name only letter`)
+    .min(1);
+};
 
-export { registration, loginSchema };
+const registrationSchema = z.object({
+  firstName: validateNames("First"),
+  lastName: validateNames("Last"),
+  confirmPassword: z.string({ message: "Passwords do not match" }),
+  dateOfBirth: z.string({ message: "Date is a required field" }).date(),
+  shippingAddress: validateAdress,
+  billingAddress: validateAdress,
+});
+
+const registration = registrationSchema.merge(loginSchema);
+
+const registrationFull = registration.omit({ billingAddress: true });
+
+export { registration, loginSchema, registrationFull };

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -70,6 +70,7 @@ function LoginPage(): ReactElement {
           type="submit"
           loading={isLoading}
           variant="contained"
+          color="success"
         >
           Login
         </LoadingButton>

--- a/src/pages/RegistrationPage/RegistrationPage.scss
+++ b/src/pages/RegistrationPage/RegistrationPage.scss
@@ -1,18 +1,16 @@
 .registration-page {
+  margin: 15px 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  max-width: 100%;
   width: 100%;
-  min-height: 100vh;
 
   .registration-page__content {
     display: flex;
     flex-direction: column;
     align-items: center;
     margin: 0px 10px;
-    padding: 50px 0px;
-    max-width: 500px;
+    padding: 25px 0px;
     width: 100%;
     border-radius: 5px;
     background-color: rgb(255, 255, 255);

--- a/src/pages/RegistrationPage/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage/RegistrationPage.tsx
@@ -1,38 +1,32 @@
-import { ReactElement } from "react";
+import { ChangeEvent, ReactElement, useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import {
   Controller,
+  FieldErrors,
   SubmitErrorHandler,
   SubmitHandler,
   useForm,
 } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import FormWrapper from "components/FormWrapper/FormWrapper";
 import FormTag from "components/Form/FormTag";
 import InputTag from "components/InputTag/InputTag";
 import ButtonTag from "components/ButtonTag/ButtonTag";
-import SelectTag from "components/SelectTag/SelectTag";
-import { registration } from "helpers/validatioinSchemes";
+import { AddressFields } from "components/AddressFields/AddressFields";
+import { registration, registrationFull } from "helpers/validatioinSchemes";
 import validateDateOfBirth from "helpers/validateDateOfBirth";
-
+import { MyCustomerDraft } from "types/API/Customer";
+import { FormTypeRegister } from "types/RegisterForm";
+import API from "api/API";
 import "./RegistrationPage.scss";
-import API from "../../api/API";
-
-type FormType = {
-  firstName: string;
-  lastName: string;
-  dateOfBirth: string;
-  country: string;
-  city: string;
-  street: string;
-  postalCode: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-};
 
 function RegistrationPage(): ReactElement {
+  const [validSchema, setValidSchema] = useState(registrationFull);
+  const [defaultShipping, setDefaultShipping] = useState<boolean>(false);
+  const [defaultBilling, setDefaultBilling] = useState<boolean>(false);
+  const [isCheckedBilling, setIsCheckedBilling] = useState<boolean>(false);
+
   const {
     control,
     handleSubmit,
@@ -41,10 +35,10 @@ function RegistrationPage(): ReactElement {
     clearErrors,
     setError,
     formState: { errors },
-  } = useForm<FormType>({
+  } = useForm<FormTypeRegister>({
     mode: "onChange",
     reValidateMode: "onChange",
-    resolver: zodResolver(registration),
+    resolver: zodResolver(validSchema),
   });
 
   const checkDate = (date: string): void => {
@@ -59,27 +53,85 @@ function RegistrationPage(): ReactElement {
     }
   };
 
-  const onChangeBirth = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  const onChangeShipping = (event: ChangeEvent<HTMLInputElement>): void => {
+    setDefaultShipping(event.target.checked);
+  };
+
+  const onChangeBilling = (event: ChangeEvent<HTMLInputElement>): void => {
+    setDefaultBilling(event.target.checked);
+  };
+
+  const onCheckedBilling = (event: ChangeEvent<HTMLInputElement>): void => {
+    setIsCheckedBilling(event.target.checked);
+  };
+
+  const onChangeBirth = (event: ChangeEvent<HTMLInputElement>): void => {
     setValue("dateOfBirth", event.target.value);
     checkDate(event.target.value);
   };
 
-  const onSubmit: SubmitHandler<FormType> = (dataForm: FormType): void => {
-    const { firstName, lastName, email, password } = dataForm;
+  const onSubmit: SubmitHandler<FormTypeRegister> = (
+    dataForm: FormTypeRegister
+  ): void => {
+    const {
+      shippingAddress,
+      billingAddress,
+      confirmPassword,
+      ...personalData
+    } = dataForm;
 
-    const newUserData = {
-      lastName,
-      firstName,
-      email,
-      password,
+    let addresses = [shippingAddress];
+    if (!isCheckedBilling) {
+      addresses = [...addresses, billingAddress];
+    }
+
+    const defaultShippingAddress = 0;
+    const defaultBillingAddress = 1;
+
+    let newUserData: MyCustomerDraft = {
+      ...personalData,
+      addresses,
     };
+
+    if (defaultShipping) {
+      newUserData = { ...newUserData, defaultShippingAddress };
+    }
+    if (isCheckedBilling) {
+      newUserData = {
+        ...newUserData,
+        defaultBillingAddress: defaultShippingAddress,
+      };
+    }
+    if (defaultBilling && !isCheckedBilling) {
+      newUserData = {
+        ...newUserData,
+        defaultBillingAddress,
+      };
+    }
+
+    console.log(newUserData);
     const clientAPI = API.getInstance();
     clientAPI?.createCustomer(newUserData);
   };
 
-  const onInvalid: SubmitErrorHandler<FormType> = (): void => {
+  const onInvalid: SubmitErrorHandler<FormTypeRegister> = (
+    error: FieldErrors<FormTypeRegister>
+  ): void => {
+    console.log(error);
     checkDate(getValues("dateOfBirth"));
   };
+
+  useEffect(() => {
+    let schema = registrationFull;
+    if (!isCheckedBilling) {
+      schema = registration;
+    }
+    schema.refine((values) => values.password === values.confirmPassword, {
+      message: "Passwords do not match",
+      path: ["confirmPassword"],
+    });
+    setValidSchema(schema);
+  }, [isCheckedBilling]);
 
   return (
     <FormWrapper title="Register">
@@ -89,159 +141,137 @@ function RegistrationPage(): ReactElement {
         url="ourURLinFuture"
         onSubmit={handleSubmit(onSubmit, onInvalid)}
       >
-        <Controller
-          name="firstName"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="text"
-              label="First name"
-              name={name}
-              onChange={onChange}
-              isError={Boolean(errors?.firstName)}
-              message={errors.firstName?.message}
+        <Grid container>
+          <Grid container xs={12} spacing={1} item>
+            <Grid item md={4} xs={12}>
+              <Controller
+                name="firstName"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="text"
+                    label="First name"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.firstName)}
+                    message={errors.firstName?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item md={4} xs={12}>
+              <Controller
+                name="lastName"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="text"
+                    label="Last name"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.lastName)}
+                    message={errors.lastName?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item md={4} xs={12}>
+              <Controller
+                name="dateOfBirth"
+                control={control}
+                render={({ field: { value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="date"
+                    label="Date of Birth"
+                    name={name}
+                    onChange={onChangeBirth}
+                    isError={Boolean(errors?.dateOfBirth)}
+                    message={errors.dateOfBirth?.message}
+                  />
+                )}
+              />
+            </Grid>
+          </Grid>
+          <AddressFields
+            typeAddress="shipping"
+            control={control}
+            errors={errors}
+            isDefault={defaultShipping}
+            isCheckedBilling={isCheckedBilling}
+            onChangeIsDefault={onChangeShipping}
+            onCheckedBilling={onCheckedBilling}
+          />
+          {!isCheckedBilling && (
+            <AddressFields
+              typeAddress="billing"
+              control={control}
+              errors={errors}
+              isDefault={defaultBilling}
+              isCheckedBilling={isCheckedBilling}
+              onChangeIsDefault={onChangeBilling}
+              onCheckedBilling={onCheckedBilling}
             />
           )}
-        />
-        <Controller
-          name="lastName"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="text"
-              label="Last name"
-              id={name}
-              onChange={onChange}
-              isError={Boolean(errors?.lastName)}
-              message={errors.lastName?.message}
-            />
-          )}
-        />
-        <Controller
-          name="dateOfBirth"
-          control={control}
-          render={({ field: { value, name } }) => (
-            <InputTag
-              value={value}
-              type="date"
-              id={name}
-              onChange={onChangeBirth}
-              isError={Boolean(errors?.dateOfBirth)}
-              message={errors.dateOfBirth?.message}
-            />
-          )}
-        />
-        <Typography sx={{ mt: 2, alignSelf: "flex-start" }} variant="body1">
-          Address
-        </Typography>
-        <Controller
-          name="country"
-          control={control}
-          render={({ field: { onChange, value } }) => (
-            <SelectTag
-              valueTag={value}
-              id="country"
-              onChange={onChange}
-              isError={Boolean(errors?.country)}
-              message={errors.country?.message}
-            />
-          )}
-        />
-        <Controller
-          name="postalCode"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="text"
-              label="Postal Code"
-              id={name}
-              onChange={onChange}
-              isError={Boolean(errors?.postalCode)}
-              message={errors.postalCode?.message}
-            />
-          )}
-        />
-        <Controller
-          name="city"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="text"
-              label="City"
-              id={name}
-              onChange={onChange}
-              isError={Boolean(errors?.city)}
-              message={errors.city?.message}
-            />
-          )}
-        />
-        <Controller
-          name="street"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="text"
-              label="Street"
-              id={name}
-              onChange={onChange}
-              isError={Boolean(errors?.street)}
-              message={errors.street?.message}
-            />
-          )}
-        />
-        <Typography sx={{ mt: 2, alignSelf: "flex-start" }} variant="body1">
-          Credentials
-        </Typography>
-        <Controller
-          name="email"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="email"
-              label="Email"
-              name={name}
-              onChange={onChange}
-              isError={Boolean(errors?.email)}
-              message={errors.email?.message}
-            />
-          )}
-        />
-        <Controller
-          name="password"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              type="password"
-              label="Password"
-              name={name}
-              onChange={onChange}
-              isError={Boolean(errors?.password)}
-              message={errors.password?.message}
-            />
-          )}
-        />
-        <Controller
-          name="confirmPassword"
-          control={control}
-          render={({ field: { onChange, value, name } }) => (
-            <InputTag
-              value={value}
-              label="Confirm Password"
-              type="password"
-              name={name}
-              onChange={onChange}
-              isError={Boolean(errors?.confirmPassword)}
-              message={errors.confirmPassword?.message}
-            />
-          )}
-        />
+          <Typography sx={{ mt: 2, alignSelf: "flex-start" }} variant="body1">
+            Credentials
+          </Typography>
+          <Grid container xs={12} spacing={1} item>
+            <Grid item xs={12}>
+              <Controller
+                name="email"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="email"
+                    label="Email"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.email)}
+                    message={errors.email?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item md={6} xs={12}>
+              <Controller
+                name="password"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="password"
+                    label="Password"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.password)}
+                    message={errors.password?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item md={6} xs={12}>
+              <Controller
+                name="confirmPassword"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    label="Confirm Password"
+                    type="password"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.confirmPassword)}
+                    message={errors.confirmPassword?.message}
+                  />
+                )}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
         <ButtonTag type="submit" title="Register" />
       </FormTag>
       <NavLink className="registration-page__content_log-in" to="/login">

--- a/src/pages/RegistrationPage/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage/RegistrationPage.tsx
@@ -9,19 +9,20 @@ import {
 } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Grid, Typography } from "@mui/material";
+import { LoadingButton } from "@mui/lab";
 import FormWrapper from "components/FormWrapper/FormWrapper";
 import FormTag from "components/Form/FormTag";
 import InputTag from "components/InputTag/InputTag";
-import ButtonTag from "components/ButtonTag/ButtonTag";
 import { AddressFields } from "components/AddressFields/AddressFields";
 import { registration, registrationFull } from "helpers/validatioinSchemes";
 import validateDateOfBirth from "helpers/validateDateOfBirth";
 import { MyCustomerDraft } from "types/API/Customer";
 import { FormTypeRegister } from "types/RegisterForm";
-import API from "api/API";
+import useAuth from "hooks/use-auth";
 import "./RegistrationPage.scss";
 
 function RegistrationPage(): ReactElement {
+  const { signup, isLoading } = useAuth();
   const [validSchema, setValidSchema] = useState(registrationFull);
   const [defaultShipping, setDefaultShipping] = useState<boolean>(false);
   const [defaultBilling, setDefaultBilling] = useState<boolean>(false);
@@ -109,9 +110,7 @@ function RegistrationPage(): ReactElement {
       };
     }
 
-    console.log(newUserData);
-    const clientAPI = API.getInstance();
-    clientAPI?.createCustomer(newUserData);
+    signup(newUserData);
   };
 
   const onInvalid: SubmitErrorHandler<FormTypeRegister> = (
@@ -272,7 +271,16 @@ function RegistrationPage(): ReactElement {
             </Grid>
           </Grid>
         </Grid>
-        <ButtonTag type="submit" title="Register" />
+        <LoadingButton
+          sx={{ m: 2, background: "rgb(70, 163, 88)" }}
+          fullWidth
+          type="submit"
+          loading={isLoading}
+          variant="contained"
+          color="success"
+        >
+          Register
+        </LoadingButton>
       </FormTag>
       <NavLink className="registration-page__content_log-in" to="/login">
         Have an account? Log In

--- a/src/reducers/authReducer.ts
+++ b/src/reducers/authReducer.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { Customer } from "types/API/Customer";
+import { Customer, MyCustomerDraft } from "types/API/Customer";
 import { LoginType } from "types/InputTagProps";
 
 interface AuthStateType {
@@ -54,10 +54,12 @@ type ActionsType =
 export interface AuthContextValue extends AuthStateType {
   logoutAccount: () => void;
   login: (data: LoginType) => Promise<void>;
+  signup: (customer: MyCustomerDraft) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextValue>({
   ...AuthInitialState,
   logoutAccount: () => {},
   login: () => Promise.resolve(),
+  signup: () => Promise.resolve(),
 });

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -31,12 +31,13 @@ const routes: RouteObject[] = [
         path: "/basket",
         element: <BasketPage />,
       },
+      { path: "/login", element: <LoginPage /> },
+      { path: "/registration", element: <RegistrationPage /> },
+      { path: "/profile", element: <div>User Profile</div> },
+      { path: "/product", element: <div>Product</div> },
     ],
   },
-  { path: "/login", element: <LoginPage /> },
-  { path: "/registration", element: <RegistrationPage /> },
-  { path: "/profile", element: <div>User Profile</div> },
-  { path: "/product", element: <div>Product</div> },
+
   { path: "/404", element: <NotFound /> },
   { path: "/*", element: <Navigate to="404" replace /> },
 ];

--- a/src/types/API/Customer.tsx
+++ b/src/types/API/Customer.tsx
@@ -10,7 +10,7 @@ export interface MyCustomerDraft {
   email: string;
   defaultShippingAddress?: number;
   defaultBillingAddress?: number;
-  dateOfBirth?: Date;
+  dateOfBirth?: string;
   companyName?: string;
   addresses?: Address[];
 }

--- a/src/types/RegisterForm.ts
+++ b/src/types/RegisterForm.ts
@@ -1,0 +1,17 @@
+type Address = {
+  country: string;
+  city: string;
+  street: string;
+  postalCode: string;
+};
+
+export type FormTypeRegister = {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  shippingAddress: Address;
+  billingAddress: Address;
+};


### PR DESCRIPTION
## Pull Request - billing and shipping addresses during registration([RSS-ECOMM-2_15](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_15.md))

### What type of PR is this?

- [x] 🌟 Feature
- [ ] 🛠 Bug Fix
- [x] ⚙️ Refactor
- [ ] 📖 Documentation

### Description

During the registration process, give users the ability to provide different addresses for billing and shipping. Users may also have the option to use the same address for both billing and shipping. Once registration is successful, the chosen addresses should be saved in the user's profile. 🏠💼

### Feature

- [x] add to the registration form separate input fields for billing and shipping addresses.
- [x] add a checkbox that users can tick if they want to use the same address for both billing and shipping.
- [x] add validation for address fields 

### Additional Information

- **Screenshots/Links:**
![image](https://github.com/Oleg-Melnikow/eCommerce/assets/14839880/05c8f64a-3747-4328-a55a-bd5b371e0f6b)

### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 🚫 My changes generate no new warnings or errors.
