### PR TITLE
Feat: RSS-ECOMM-3_17 Implement Password Change in User Profile Page

### DIFF
--- a/src/api/API.tsx
+++ b/src/api/API.tsx
@@ -10,7 +10,11 @@ import { ProductData, Products, ProductsSearch } from "types/API/Product";
 import { Categories } from "types/API/Category";
 import { AuthContextValue } from "reducers/authReducer";
 import errorHandler from "helpers/errorHandler";
-import { ActionAddressType, DeleteParamsType } from "types/RegisterForm";
+import {
+  ActionAddressType,
+  ChangePasswordType,
+  DeleteParamsType,
+} from "types/RegisterForm";
 
 export default class API {
   protected static instance: API | null = null;
@@ -310,6 +314,22 @@ export default class API {
         const response = await this.apiInstance?.post(`/customers/${id}`, {
           version,
           actions: [{ action, addressId }],
+        });
+        return response?.data as Customer;
+      })
+      .catch((err) => {
+        const message = errorHandler(err);
+        throw new Error(message);
+      });
+  }
+
+  public async changePassword(
+    passwordData: ChangePasswordType
+  ): Promise<Customer> {
+    return this.createAPI()
+      .then(async () => {
+        const response = await this.apiInstance?.post(`/customers/password`, {
+          ...passwordData,
         });
         return response?.data as Customer;
       })

--- a/src/components/AddressesTable/AddressTypeUpdate.tsx
+++ b/src/components/AddressesTable/AddressTypeUpdate.tsx
@@ -27,8 +27,6 @@ export function AddressTypeUpdate({ id }: PropsType): ReactElement {
         version: user.version,
       });
     }
-
-    console.log(event.target.checked, event.target.name);
   };
 
   const onChangeAddressType = async (

--- a/src/components/AddressesTable/UpdateAddressForm.tsx
+++ b/src/components/AddressesTable/UpdateAddressForm.tsx
@@ -12,7 +12,13 @@ import { validatePostalCode } from "helpers/validatePostalCode";
 import { validateAdress } from "helpers/validatioinSchemes";
 import useAuth from "hooks/use-auth";
 import { ChangeEvent, ReactElement } from "react";
-import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import {
+  Controller,
+  FieldErrors,
+  SubmitErrorHandler,
+  SubmitHandler,
+  useForm,
+} from "react-hook-form";
 import { Address } from "types/API/Customer";
 
 type FormValues = {
@@ -57,6 +63,12 @@ export function UpdateAddressForm({
     }
   };
 
+  const validateCode = (): void => {
+    const country = getValues(`country`);
+    const code = getValues(`postalCode`);
+    checkPostCode(code, country);
+  };
+
   const onChangeSelect = (event: SelectChangeEvent): void => {
     const { value } = event.target;
     const post = getValues("postalCode");
@@ -73,16 +85,26 @@ export function UpdateAddressForm({
   };
 
   const onSubmit: SubmitHandler<FormValues> = async (dataForm: FormValues) => {
-    if (user && address?.id) {
-      await updateUserAdress(user.id, user.version, dataForm, address.id);
-    }
-    if (user && !address) {
-      await updateUserAdress(user.id, user.version, dataForm);
+    validateCode();
+    if (!Object.keys(errors).length) {
+      if (user && address?.id) {
+        await updateUserAdress(user.id, user.version, dataForm, address.id);
+      }
+      if (user && !address) {
+        await updateUserAdress(user.id, user.version, dataForm);
+      }
     }
   };
 
+  const onInvalid: SubmitErrorHandler<FormValues> = (
+    error: FieldErrors<FormValues>
+  ): void => {
+    console.log(error);
+    validateCode();
+  };
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit, onInvalid)}>
       <CardContent>
         <Grid container xs={12} spacing={1} item>
           <Grid item md={size} xs={12}>

--- a/src/components/ChangePasswordProfile/ChangePasswordProfile.tsx
+++ b/src/components/ChangePasswordProfile/ChangePasswordProfile.tsx
@@ -1,0 +1,98 @@
+import { ReactElement } from "react";
+import useAuth from "hooks/use-auth";
+import { LoadingButton } from "@mui/lab";
+import { Box, Grid, Typography } from "@mui/material";
+import { zodResolver } from "@hookform/resolvers/zod";
+import InputTag from "components/InputTag/InputTag";
+import LoaderItem from "components/LoaderItem/LoaderItem";
+import { changePasswordSchema } from "helpers/validatioinSchemes";
+
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+
+type FormValues = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+export function ChangePasswordProfile(): ReactElement {
+  const { isLoading, user, changePassword } = useAuth();
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    mode: "onChange",
+    reValidateMode: "onChange",
+    resolver: zodResolver(changePasswordSchema),
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (dataForm: FormValues) => {
+    if (user) {
+      await changePassword({ id: user.id, version: user.version, ...dataForm });
+    }
+  };
+
+  return (
+    <>
+      {isLoading && <LoaderItem />}
+      <Box>
+        <Typography sx={{ p: 0, textAlign: "center" }} variant="h6">
+          You can change Password
+        </Typography>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          style={{ display: "flex", justifyContent: "center" }}
+        >
+          <Grid container md={6} sm={8} xs={12} spacing={1} item>
+            <Grid item xs={12}>
+              <Controller
+                name="currentPassword"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="password"
+                    label="Current Password"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.currentPassword)}
+                    message={errors.currentPassword?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Controller
+                name="newPassword"
+                control={control}
+                render={({ field: { onChange, value, name } }) => (
+                  <InputTag
+                    value={value}
+                    type="password"
+                    label="New Password"
+                    name={name}
+                    onChange={onChange}
+                    isError={Boolean(errors?.newPassword)}
+                    message={errors.newPassword?.message}
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <LoadingButton
+                sx={{ mt: 2, background: "rgb(70, 163, 88)" }}
+                fullWidth
+                type="submit"
+                loading={isLoading}
+                variant="contained"
+                color="success"
+              >
+                Set new password
+              </LoadingButton>
+            </Grid>
+          </Grid>
+        </form>
+      </Box>
+    </>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -15,6 +15,7 @@ import { Customer, MyCustomerDraft } from "types/API/Customer";
 import {
   ActionAddressType,
   AddressForm,
+  ChangePasswordType,
   DeleteParamsType,
 } from "types/RegisterForm";
 import {
@@ -41,6 +42,27 @@ export function AuthProvider(props: AuthProviderProps): ReactElement {
     dispatch(initialize(true, response));
   };
 
+  const changePassword = useCallback(
+    async (passwordData: ChangePasswordType) => {
+      dispatch(loading(true));
+      try {
+        const clientAPI = API.getInstance();
+        const response = await clientAPI?.changePassword(passwordData);
+        if (response) {
+          saveUserData(response);
+        }
+        toast.success("Password was changed successfully!", toastOptions);
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error?.message, toastOptions);
+        }
+      } finally {
+        dispatch(loading(false));
+      }
+    },
+    []
+  );
+
   const updateUserAdress = useCallback(
     async (
       id: string,
@@ -62,6 +84,10 @@ export function AuthProvider(props: AuthProviderProps): ReactElement {
         if (response) {
           saveUserData(response);
         }
+        toast.success(
+          `Address was ${addressId ? "changed" : "added"} successfully!`,
+          toastOptions
+        );
       } catch (error) {
         if (error instanceof Error) {
           toast.error(error?.message, toastOptions);
@@ -81,6 +107,9 @@ export function AuthProvider(props: AuthProviderProps): ReactElement {
       if (response) {
         saveUserData(response);
       }
+      const message =
+        params.action === "removeAddress" ? "removed" : "changed type";
+      toast.success(`Address was ${message} successfully!`, toastOptions);
     } catch (error) {
       if (error instanceof Error) {
         toast.error(error?.message, toastOptions);
@@ -197,6 +226,7 @@ export function AuthProvider(props: AuthProviderProps): ReactElement {
       tokenReceiving,
       updateUserAdress,
       changeUserAdress,
+      changePassword,
     }),
     [
       state,
@@ -206,6 +236,7 @@ export function AuthProvider(props: AuthProviderProps): ReactElement {
       tokenReceiving,
       updateUserAdress,
       changeUserAdress,
+      changePassword,
     ]
   );
 

--- a/src/helpers/errorHandler.tsx
+++ b/src/helpers/errorHandler.tsx
@@ -17,7 +17,10 @@ export default function errorHandler(axiosError: unknown): string {
       errorMessageInner =
         "Error registration user: re-registration of an already registered user.\nPlease, login or use another email address.";
       break;
-
+    case "The given current password does not match.":
+      errorMessageInner =
+        "The given current password does not match. Please enter the correct password.";
+      break;
     default:
       errorMessageInner =
         "Something went wrong during the registration process. Please, should try again later.";

--- a/src/helpers/validatioinSchemes.ts
+++ b/src/helpers/validatioinSchemes.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+const passwordValid = z
+  .string({ message: "Password is a required field" })
+  .regex(/^\S*$/, "Leading spaces are not allowed")
+  .regex(/(?=.*[A-Z])/, "Must contain at least one uppercase letter")
+  .regex(/(?=.*[a-z])/, "Must contain at least one lowercase letter")
+  .regex(/(?=.*[0-9])/, "Must contain at least one digit")
+  .regex(
+    /(?=.*[!@#\\$%\\^&\\*])/,
+    "Must contain at least one special character"
+  )
+  .min(8)
+  .max(32);
+
 const loginSchema = z.object({
   email: z
     .string({ message: "Email is a required field" })
@@ -7,18 +20,7 @@ const loginSchema = z.object({
     .includes("@", { message: `Email must be include '@'` })
     .regex(/@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$/, "Domain not allowed")
     .email({ message: "Email is not valid" }),
-  password: z
-    .string({ message: "Password is a required field" })
-    .regex(/^\S*$/, "Leading spaces are not allowed")
-    .regex(/(?=.*[A-Z])/, "Must contain at least one uppercase letter")
-    .regex(/(?=.*[a-z])/, "Must contain at least one lowercase letter")
-    .regex(/(?=.*[0-9])/, "Must contain at least one digit")
-    .regex(
-      /(?=.*[!@#\\$%\\^&\\*])/,
-      "Must contain at least one special character"
-    )
-    .min(8)
-    .max(32),
+  password: passwordValid,
 });
 
 const validateAdress = z.object({
@@ -47,8 +49,19 @@ const registrationSchema = z.object({
   billingAddress: validateAdress,
 });
 
+const changePasswordSchema = z.object({
+  currentPassword: passwordValid,
+  newPassword: passwordValid,
+});
+
 const registration = registrationSchema.merge(loginSchema);
 
 const registrationFull = registration.omit({ billingAddress: true });
 
-export { registration, loginSchema, registrationFull, validateAdress };
+export {
+  registration,
+  loginSchema,
+  registrationFull,
+  validateAdress,
+  changePasswordSchema,
+};

--- a/src/pages/UserProfilePage/TabPanelContent/TabAddressesData/TabAddressesData.tsx
+++ b/src/pages/UserProfilePage/TabPanelContent/TabAddressesData/TabAddressesData.tsx
@@ -2,8 +2,6 @@ import { ReactElement, useState } from "react";
 import { AddressListItem } from "components/AddressesTable/AddressListItem";
 import useAuth from "hooks/use-auth";
 import {
-  Button,
-  Dialog,
   Paper,
   Table,
   TableBody,
@@ -13,11 +11,12 @@ import {
   TableRow,
 } from "@mui/material";
 import { AddAddressModal } from "components/AddressesTable/AddAddressModal";
+import LoaderItem from "components/LoaderItem/LoaderItem";
 
 const addressesTitle = ["Country", "City", "Street", "PostalCode"];
 
 function AddressesTable(): ReactElement {
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
 
   const [openAddress, setOpenAddress] = useState<string>("");
 
@@ -27,6 +26,7 @@ function AddressesTable(): ReactElement {
 
   return (
     <>
+      {isLoading && <LoaderItem />}
       <AddAddressModal />
       <TableContainer component={Paper}>
         <Table sx={{ minWidth: 380 }} aria-label="simple table">

--- a/src/pages/UserProfilePage/Tabs/Tabs.tsx
+++ b/src/pages/UserProfilePage/Tabs/Tabs.tsx
@@ -1,29 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React, { SyntheticEvent, useEffect, useState } from "react";
 import useAuth from "hooks/use-auth";
 import { UserPersonalData } from "types/UserProfileDataProps/UserProfileDataProps";
-import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
-import Box from "@mui/material/Box";
+import { ChangePasswordProfile } from "components/ChangePasswordProfile/ChangePasswordProfile";
+import { Box, Tab, Tabs } from "@mui/material";
 import CustomTabPanel from "../TabPanel/TabPanel";
 import TabPersonalData from "../TabPanelContent/TabUserPersonalData/TabPersonalData";
 import AddressesTable from "../TabPanelContent/TabAddressesData/TabAddressesData";
 import "./Tabs.scss";
 
-interface A11yPropsReturn {
-  id: string;
-  "aria-controls": string;
-}
-function a11yProps(index: number): A11yPropsReturn {
-  return {
-    id: `simple-tab-${index}`,
-    "aria-controls": `simple-tabpanel-${index}`,
-  };
-}
-
 function BasicTabs(): JSX.Element {
-  const [value, setValue] = React.useState(0);
   const { user } = useAuth();
-
+  const [value, setValue] = React.useState(0);
   const [userPersonalData, setUserPersonalData] = useState<UserPersonalData>();
 
   useEffect(() => {
@@ -33,30 +20,26 @@ function BasicTabs(): JSX.Element {
     }
   }, [user]);
 
-  const handleChange = (
-    event: React.SyntheticEvent,
-    newValue: number
-  ): void => {
+  const handleChange = (event: SyntheticEvent, newValue: number): void => {
     setValue(newValue);
   };
 
   return (
     <Box sx={{ width: "100%" }}>
       <Box sx={{ borderBottom: 1, borderColor: "#727272" }}>
-        <Tabs
-          value={value}
-          onChange={handleChange}
-          aria-label="basic tabs example"
-        >
-          <Tab label="Personal" {...a11yProps(0)} />
-          <Tab label="Addresses" {...a11yProps(1)} />
+        <Tabs value={value} onChange={handleChange}>
+          {["Personal", "Password", "Addresses"].map((tab, index) => {
+            return <Tab sx={{ p: 1 }} key={tab} label={tab} value={index} />;
+          })}
         </Tabs>
       </Box>
-
       <CustomTabPanel value={value} index={0}>
         {userPersonalData && <TabPersonalData userData={userPersonalData} />}
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
+        <ChangePasswordProfile />
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={2}>
         <AddressesTable />
       </CustomTabPanel>
     </Box>

--- a/src/pages/UserProfilePage/UserProfilePage.scss
+++ b/src/pages/UserProfilePage/UserProfilePage.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  margin-top: 50px;
+  margin-top: 20px;
   max-width: 100%;
   width: 100%;
 
@@ -11,15 +11,15 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    gap: 10px;
 
     .wrapper__content_title {
-      padding: 18px 18px;
+      padding: 10px;
       font-family: "Noto Sans", sans-serif;
-      font-size: 18px;
+      font-size: 22px;
       font-weight: 700;
       line-height: 16px;
       color: rgb(61, 61, 61);
-      background-color: rgb(251, 251, 251);
     }
   }
 }

--- a/src/reducers/authReducer.ts
+++ b/src/reducers/authReducer.ts
@@ -1,7 +1,11 @@
 import { createContext } from "react";
 import { Customer, MyCustomerDraft } from "types/API/Customer";
 import { LoginType } from "types/InputTagProps";
-import { AddressForm, DeleteParamsType } from "types/RegisterForm";
+import {
+  AddressForm,
+  ChangePasswordType,
+  DeleteParamsType,
+} from "types/RegisterForm";
 
 interface AuthStateType {
   isAuthenticated: boolean;
@@ -73,6 +77,7 @@ export interface AuthContextValue extends AuthStateType {
     addressId?: string
   ) => Promise<void>;
   changeUserAdress: (params: DeleteParamsType) => Promise<void>;
+  changePassword: (passwordData: ChangePasswordType) => Promise<void>;
   tokenReceiving: () => void;
 }
 
@@ -83,5 +88,6 @@ export const AuthContext = createContext<AuthContextValue>({
   signup: () => Promise.resolve(),
   updateUserAdress: () => Promise.resolve(),
   changeUserAdress: () => Promise.resolve(),
+  changePassword: () => Promise.resolve(),
   tokenReceiving: () => {},
 });

--- a/src/types/RegisterForm.ts
+++ b/src/types/RegisterForm.ts
@@ -37,3 +37,10 @@ export type AddressActionType =
   | "removeShippingAddressId"
   | "addBillingAddressId"
   | "removeBillingAddressId";
+
+export interface ChangePasswordType {
+  id: string;
+  version: number;
+  currentPassword: string;
+  newPassword: string;
+}


### PR DESCRIPTION
## Pull Request - Implement Password Change in User Profile Page([RSS-ECOMM-3_17](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_17.md))

### What type of PR is this?

- [x] 🌟 Feature
- [ ] 🛠 Bug Fix
- [x] ⚙️ Refactor
- [ ] 📖 Documentation

### Description
Users should have the capability to update their password 🔑 within the application independently. This feature increases user autonomy and ensures they can maintain their account security up-to-date.

###  Implementation Details 🔨

1. **Separate Change Password Option:** Provide a distinct option for users to change their password independently from other personal information.
2. **Form Validation:** Ensure the updated password meets the necessary criteria (minimum length, complexity, etc.).
3. **Current Password Verification:** Confirm the user's current password before applying the change.
4. **Saving Changes:** Provide a mechanism to save changes made in the password change mode, ideally with a clear indication (such as a button) that signifies saving changes.
5. **Backend Integration:** Implement the password change by integrating with the commercetools platform, following the appropriate API guidelines.
6. **Re-authentication:** Trigger re-authentication if needed, according to the authentication/authentication flow requirements for commercetools applications.

### Additional Information

![image](https://github.com/Oleg-Melnikow/eCommerce/assets/14839880/d41fa0a1-2031-45cb-a8ff-828db458e430)

### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
